### PR TITLE
build: cache node_modules via github actions step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - run: npm run audit
       - run: npm ci
       - run: npm run lint --if-present
       - run: npm run build --if-present
       - run: npm test
-        env:
-          CI: true
       - name: Archive npm audit results
         if: always()
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Ref:
- https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows